### PR TITLE
Make user able to get item's info or edit item directly from AlbumActivity

### DIFF
--- a/app/src/main/java/us/koller/cameraroll/ui/AlbumActivity.java
+++ b/app/src/main/java/us/koller/cameraroll/ui/AlbumActivity.java
@@ -470,6 +470,8 @@ public class AlbumActivity extends ThemeableActivity
             menu.findItem(R.id.rename).setVisible(false);
             menu.findItem(R.id.copy).setVisible(false);
             menu.findItem(R.id.move).setVisible(false);
+            menu.findItem(R.id.info).setVisible(false);
+            menu.findItem(R.id.edit).setVisible(false);
         } else if (album != null) {
             setupMenu();
         }
@@ -502,6 +504,9 @@ public class AlbumActivity extends ThemeableActivity
             menu.findItem(R.id.copy).setVisible(selectorModeActive);
             menu.findItem(R.id.move).setVisible(selectorModeActive);
             menu.findItem(R.id.select_all).setVisible(selectorModeActive);
+            //show info & edit button, but their visibility would change as selected items change
+            menu.findItem(R.id.info).setVisible(selectorModeActive);
+            menu.findItem(R.id.edit).setVisible(selectorModeActive);
         }
     }
 
@@ -555,6 +560,11 @@ public class AlbumActivity extends ThemeableActivity
                 intent.putExtra(FileOperationDialogActivity.FILES, selected_items_paths);
 
                 startActivityForResult(intent, FILE_OP_DIALOG_REQUEST);
+                break;
+            case R.id.info:
+                //show item info
+                break;
+            case R.id.edit:
                 break;
             case R.id.exclude:
                 Provider.loadExcludedPaths(this);
@@ -921,6 +931,10 @@ public class AlbumActivity extends ThemeableActivity
                 } else {
                     setPhotosResult();
                 }
+            } else if (menu != null) {
+                //show info & edit button only if a single item is selected
+                menu.findItem(R.id.info).setVisible(selectedItemCount == 1);
+                menu.findItem(R.id.edit).setVisible(selectedItemCount == 1);
             }
         } else {
             if (pick_photos) {

--- a/app/src/main/res/menu/album.xml
+++ b/app/src/main/res/menu/album.xml
@@ -33,6 +33,18 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/info"
+        android:icon="@drawable/ic_info_white_24dp"
+        android:title="@string/info"
+        android:visible="false"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/edit"
+        android:icon="@drawable/ic_edit_white_24dp"
+        android:title="@string/edit"
+        android:visible="false"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/sort_by"
         android:icon="@drawable/ic_sort_white_24dp"
         android:title="@string/sort_by"

--- a/app/src/main/res/menu/selector_mode.xml
+++ b/app/src/main/res/menu/selector_mode.xml
@@ -25,4 +25,14 @@
         android:icon="@drawable/ic_delete_white_24dp"
         android:title="@string/delete"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/info"
+        android:icon="@drawable/ic_info_white_24dp"
+        android:title="@string/info"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/edit"
+        android:icon="@drawable/ic_edit_white_24dp"
+        android:title="@string/edit"
+        app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
When using other gallery apps, I'm used to select a picture and view its info or edit it, but this app is lack of this function, this is exactly what this pr does (the `info` and `edit` button is visible only if a single item is selected):

![screenshot_20171021-223344](https://user-images.githubusercontent.com/17007549/31852776-857fd8a4-b6b0-11e7-977d-8c4bc32454d5.png)

You can also do this from MainActivity in parallax mode:

![screenshot_20171021-223420](https://user-images.githubusercontent.com/17007549/31852777-8a370598-b6b0-11e7-829d-67b6f345dcb1.png)

But **DO NOT** accept this pr so quick, the function is yet not completed (`info` button currently does nothing). Cause when working on it, I find that there is a bunch of duplicate code here and there, most of which is related to some frequently used function: copy, paste, share, info, delete, edit... So I'm wondering if we should put them all into a package to make the overall structure more clear, just like `us.koller.cameraroll.data.fileOperations`, maybe it could be `us.koller.cameraroll.data.itemOperations`.
